### PR TITLE
[date-format] Align CI Node version and stabilize timezone-sensitive tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/packages/date-format/tests/fp/fp-formatters.test.ts
+++ b/packages/date-format/tests/fp/fp-formatters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { startOfDay as dateFnsStartOfDay } from 'date-fns';
 import {
   formatAsDate,
   formatAsDateEx,
@@ -43,7 +44,7 @@ describe('日期函数式 API', () => {
   it('应该复用 date-fns 的 startOfDay 调整到日初', () => {
     const result = formatAsStartOfDayEx(SAMPLE_DATE, { timeZone: 'UTC' });
 
-    expect(result.date?.toISOString()).toBe('2024-05-20T00:00:00.000Z');
+    expect(result.date?.getTime()).toBe(dateFnsStartOfDay(SAMPLE_DATE).getTime());
     expect(result.formattedValue).toBe('2024/5/20 00:00');
   });
 
@@ -71,8 +72,9 @@ describe('日期函数式 API', () => {
   });
 
   it('应该直接从包入口二次导出 date-fns 的 startOfDay', () => {
-    const normalized = exportedStartOfDay(new Date('2024-05-20T18:00:00Z'));
+    const input = new Date('2024-05-20T18:00:00Z');
+    const normalized = exportedStartOfDay(input);
 
-    expect(normalized.toISOString()).toBe('2024-05-20T00:00:00.000Z');
+    expect(normalized.getTime()).toBe(dateFnsStartOfDay(input).getTime());
   });
 });

--- a/packages/date-format/tests/utils/shortcuts.test.ts
+++ b/packages/date-format/tests/utils/shortcuts.test.ts
@@ -1,4 +1,14 @@
-import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  addDays,
+  addMonths,
+  addQuarters,
+  addWeeks,
+  startOfDay,
+  startOfMonth,
+  startOfQuarter,
+  startOfWeek,
+} from 'date-fns';
 import {
   getTodayDate,
   getTomorrowDate,
@@ -15,6 +25,14 @@ import {
 
 const BASE_TIME = new Date('2024-05-20T10:30:00.000Z');
 
+function expectSameTimestamp(received: Date, expected: Date) {
+  expect(received.getTime()).toBe(expected.getTime());
+}
+
+function getStartOfTodayReference(): Date {
+  return startOfDay(BASE_TIME);
+}
+
 describe('日期快捷函数', () => {
   beforeAll(() => {
     vi.useFakeTimers();
@@ -26,23 +44,47 @@ describe('日期快捷函数', () => {
   });
 
   it('应该返回今天、昨天、明天及前后天的零点', () => {
-    expect(getTodayDate().toISOString()).toBe('2024-05-20T00:00:00.000Z');
-    expect(getYesterdayDate().toISOString()).toBe('2024-05-19T00:00:00.000Z');
-    expect(getTomorrowDate().toISOString()).toBe('2024-05-21T00:00:00.000Z');
-    expect(getDayBeforeYesterdayDate().toISOString()).toBe('2024-05-18T00:00:00.000Z');
-    expect(getDayAfterTomorrowDate().toISOString()).toBe('2024-05-22T00:00:00.000Z');
+    const startOfToday = getStartOfTodayReference();
+
+    expectSameTimestamp(getTodayDate(), startOfToday);
+    expectSameTimestamp(getYesterdayDate(), addDays(startOfToday, -1));
+    expectSameTimestamp(getTomorrowDate(), addDays(startOfToday, 1));
+    expectSameTimestamp(getDayBeforeYesterdayDate(), addDays(startOfToday, -2));
+    expectSameTimestamp(getDayAfterTomorrowDate(), addDays(startOfToday, 2));
   });
 
   it('应该正确计算周起始日期', () => {
-    expect(getStartOfPreviousWeek().toISOString()).toBe('2024-05-13T00:00:00.000Z');
-    expect(getStartOfNextWeek().toISOString()).toBe('2024-05-27T00:00:00.000Z');
-    expect(getStartOfNextWeek({ weekStartsOn: 0 }).toISOString()).toBe('2024-05-26T00:00:00.000Z');
+    const startOfToday = getStartOfTodayReference();
+
+    expectSameTimestamp(
+      getStartOfPreviousWeek(),
+      startOfWeek(addWeeks(startOfToday, -1), { weekStartsOn: 1 }),
+    );
+    expectSameTimestamp(
+      getStartOfNextWeek(),
+      startOfWeek(addWeeks(startOfToday, 1), { weekStartsOn: 1 }),
+    );
+    expectSameTimestamp(
+      getStartOfNextWeek({ weekStartsOn: 0 }),
+      startOfWeek(addWeeks(startOfToday, 1), { weekStartsOn: 0 }),
+    );
   });
 
   it('应该正确计算月度与季度的开始时间', () => {
-    expect(getStartOfPreviousMonth().toISOString()).toBe('2024-04-01T00:00:00.000Z');
-    expect(getStartOfNextMonth().toISOString()).toBe('2024-06-01T00:00:00.000Z');
-    expect(getStartOfPreviousQuarter().toISOString()).toBe('2024-01-01T00:00:00.000Z');
-    expect(getStartOfNextQuarter().toISOString()).toBe('2024-07-01T00:00:00.000Z');
+    const startOfToday = getStartOfTodayReference();
+
+    expectSameTimestamp(
+      getStartOfPreviousMonth(),
+      startOfMonth(addMonths(startOfToday, -1)),
+    );
+    expectSameTimestamp(getStartOfNextMonth(), startOfMonth(addMonths(startOfToday, 1)));
+    expectSameTimestamp(
+      getStartOfPreviousQuarter(),
+      startOfQuarter(addQuarters(startOfToday, -1)),
+    );
+    expectSameTimestamp(
+      getStartOfNextQuarter(),
+      startOfQuarter(addQuarters(startOfToday, 1)),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- update CI and docs workflows to use Node 22 in line with the workspace toolchain
- make date-format shortcut and start-of-day tests compare timestamps so they no longer rely on environment timezones

## Testing
- pnpm --filter @internationalized/date-format test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d20baa67548332bf4210a11ba6553e